### PR TITLE
Improve error message for when semantic.json cannot be found

### DIFF
--- a/tasks/config/user.js
+++ b/tasks/config/user.js
@@ -29,10 +29,13 @@ var
 try {
   // looks for config file across all parent directories
   userConfig = requireDotFile('semantic.json', process.cwd());
+  if(userConfig.valueOf() === false) {
+    console.error('No semantic.json config found');
+  }
 }
 catch(error) {
   if(error.code === 'MODULE_NOT_FOUND') {
-    console.error('No semantic.json config found');
+    console.error('require-dot-file module not found');
   }
 }
 


### PR DESCRIPTION
<!--
 Please read our Contributing Guide and Code of Conduct before you
 submit a pull request.
  
 Contributing Guide: https://github.com/fomantic/Fomantic-UI/blob/master/CONTRIBUTING.md
 Code of Conduct: https://github.com/fomantic/Fomantic-UI/blob/master/CODE_OF_CONDUCT.md

 ----

 Please use the following pull request title format:
 "[<scope>] <summary of what you fixed/changed>"
-->

## Description
Improve error message for when `semantic.json` cannot be found.

I was having an issue with my setup where `semantic.json` couldn't be found. Looking at require-dot-file, it seems `false` is returned when `semantic.json` isn't there. An error is printed only when the `MODULE_NOT_FOUND` error is thrown which wasn't happening in my case.